### PR TITLE
Fix type-only import for Answer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,20 @@
+import { QuizProvider } from './context/quizContext';
+import { QuizForm } from './components/QuizForm';
+import type { Question } from './types/quiz';
+
+function App() {
+  const handleQuizSubmit = (questions: Question[]) => {
+    console.log('Quiz submitted:', questions);
+  };
+
+  return (
+    <QuizProvider>
+      <div style={{ padding: '20px' }}>
+        <h1>Quiz App</h1>
+        <QuizForm onSubmit={handleQuizSubmit} />
+      </div>
+    </QuizProvider>
+  );
+}
+
+export default App;

--- a/src/components/QuizForm.tsx
+++ b/src/components/QuizForm.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+// CORRECT: Using type-only imports for types
+import type { Question } from '../types/quiz';
+
+interface QuizFormProps {
+  onSubmit: (questions: Question[]) => void;
+}
+
+export const QuizForm: React.FC<QuizFormProps> = ({ onSubmit }) => {
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [currentQuestion, setCurrentQuestion] = useState<string>('');
+
+  const addQuestion = () => {
+    if (currentQuestion.trim()) {
+      const newQuestion: Question = {
+        id: Date.now().toString(),
+        text: currentQuestion,
+        answers: []
+      };
+      setQuestions([...questions, newQuestion]);
+      setCurrentQuestion('');
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(questions);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label htmlFor="question">Question:</label>
+        <input
+          id="question"
+          type="text"
+          value={currentQuestion}
+          onChange={(e) => setCurrentQuestion(e.target.value)}
+        />
+        <button type="button" onClick={addQuestion}>
+          Add Question
+        </button>
+      </div>
+      <div>
+        <h3>Questions ({questions.length})</h3>
+        {questions.map((question) => (
+          <div key={question.id}>
+            <p>{question.text}</p>
+          </div>
+        ))}
+      </div>
+      <button type="submit">Submit Quiz</button>
+    </form>
+  );
+};

--- a/src/context/quizContext.tsx
+++ b/src/context/quizContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, type ReactNode } from 'react';
 // CORRECT: Using type-only import for the Quiz type
 import type { Quiz } from '../types/quiz';
 

--- a/src/context/quizContext.tsx
+++ b/src/context/quizContext.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+// CORRECT: Using type-only import for the Quiz type
+import type { Quiz } from '../types/quiz';
+
+interface QuizContextType {
+  currentQuiz: Quiz | null;
+  setCurrentQuiz: (quiz: Quiz | null) => void;
+  quizzes: Quiz[];
+  addQuiz: (quiz: Quiz) => void;
+}
+
+const QuizContext = createContext<QuizContextType | undefined>(undefined);
+
+interface QuizProviderProps {
+  children: ReactNode;
+}
+
+export const QuizProvider: React.FC<QuizProviderProps> = ({ children }) => {
+  const [currentQuiz, setCurrentQuiz] = useState<Quiz | null>(null);
+  const [quizzes, setQuizzes] = useState<Quiz[]>([]);
+
+  const addQuiz = (quiz: Quiz) => {
+    setQuizzes(prev => [...prev, quiz]);
+  };
+
+  const value: QuizContextType = {
+    currentQuiz,
+    setCurrentQuiz,
+    quizzes,
+    addQuiz
+  };
+
+  return (
+    <QuizContext.Provider value={value}>
+      {children}
+    </QuizContext.Provider>
+  );
+};
+
+export const useQuiz = (): QuizContextType => {
+  const context = useContext(QuizContext);
+  if (context === undefined) {
+    throw new Error('useQuiz must be used within a QuizProvider');
+  }
+  return context;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.tsx'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/src/types/quiz.ts
+++ b/src/types/quiz.ts
@@ -1,0 +1,18 @@
+export interface Answer {
+  id: string;
+  text: string;
+  isCorrect: boolean;
+}
+
+export interface Question {
+  id: string;
+  text: string;
+  answers: Answer[];
+}
+
+export interface Quiz {
+  id: string;
+  title: string;
+  description?: string;
+  questions: Question[];
+}


### PR DESCRIPTION
Sets up a minimal React project demonstrating type-only imports to resolve TypeScript errors related to `verbatimModuleSyntax`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5c9bbad-eaca-453f-9a4f-ee1743842960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5c9bbad-eaca-453f-9a4f-ee1743842960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>